### PR TITLE
Fix links in js responses

### DIFF
--- a/app/views/spree/favorites/create.js.erb
+++ b/app/views/spree/favorites/create.js.erb
@@ -1,6 +1,6 @@
 <% if @favorite.persisted? %>
   var $el = document.querySelector("#favorable_<%= @favorite.favorable_type.demodulize.underscore %>_<%= @favorite.favorable_id %>");
 
-  $el.href = '<%= favorite_path(@favorite, favorable_id: @favorite.favorable_id, favorable_type: @favorite.favorable_type) %>';
+  $el.href = '<%= raw favorite_path(@favorite, favorable_id: @favorite.favorable_id, favorable_type: @favorite.favorable_type) %>';
   $el.dataset.method = 'delete';
 <% end %>

--- a/app/views/spree/favorites/destroy.js.erb
+++ b/app/views/spree/favorites/destroy.js.erb
@@ -2,7 +2,7 @@
   var $el = document.querySelector("#favorable_<%= @favorite.favorable_type.demodulize.underscore %>_<%= @favorite.favorable_id %>");
 
   if ($el) {
-    $el.href = '<%= favorites_path(favorable_id: @favorite.favorable_id, favorable_type: @favorite.favorable_type) %>';
+    $el.href = '<%= raw favorites_path(favorable_id: @favorite.favorable_id, favorable_type: @favorite.favorable_type) %>';
     $el.dataset.method = 'post';
   } else {
     $("#favorite_<%= @favorite.id %>").remove();


### PR DESCRIPTION
Rails auto html encodes all output - `favorite_path` produces link with `&` which becomes `&amp;`
On submission Rails logs show: `Unpermitted parameter: :amp`