### PR TITLE
Handle unauthenticated users

### DIFF
--- a/app/assets/javascripts/spree/frontend/solidus_favorites.js
+++ b/app/assets/javascripts/spree/frontend/solidus_favorites.js
@@ -1,15 +1,37 @@
 Spree.ready(function() {
-  $('.favorite_product_link').on('click', function(e) {
-    e.preventDefault();
+  (function () {
+    var favoriteLink = $(".favorite_product_link");
 
-    var $el = $(e.currentTarget);
+    favoriteLink.on("click", function (e) {
+      e.preventDefault();
 
-    if ($el.hasClass('fa-heart-o')) {
-      $el.removeClass('fa-heart-o').addClass('fa-heart');
-    } else {
-      $el.removeClass('fa-heart').addClass('fa-heart-o');
-    }
-  })
+      var $el = $(e.currentTarget);
+
+      if ($el.hasClass("fa-heart-o")) {
+        $el.removeClass("fa-heart-o").addClass("fa-heart");
+      } else {
+        $el.removeClass("fa-heart").addClass("fa-heart-o");
+      }
+    });
+
+    var urlParams = new URLSearchParams(window.location.search);
+    var favorableId = urlParams.get("favorable_id");
+    var favorableType = urlParams.get("favorable_type");
+
+    if (!favorableId || !favorableType) return;
+
+    favoriteLink.each(function () {
+      var $el = $(this);
+
+      if (
+        $el.hasClass("fa-heart-o") &&
+        ($el.data("favorable-id") || 0).toString() === favorableId &&
+        $el.data("favorable-type") === favorableType
+      ) {
+        $el.click();
+      }
+    });
+  })();
 
   $('.favorite_add_to_cart_link').on('click', function(e) {
     e.preventDefault();

--- a/app/controllers/spree/favorites_controller.rb
+++ b/app/controllers/spree/favorites_controller.rb
@@ -4,6 +4,8 @@ module Spree
   class FavoritesController < Spree::StoreController
     helper SolidusFavorites::FavoritesHelper
 
+    prepend_before_action :store_favorite_product_preference, only: :create
+    before_action :authenticate_spree_user!
     before_action :favorite, only: [:destroy]
 
     respond_to :html, :js
@@ -48,6 +50,14 @@ module Spree
 
     def model_class
       Spree::Favorite
+    end
+
+    def store_favorite_product_preference
+      return if spree_current_user
+
+      session[:spree_user_return_to] =
+        product_url(id: params[:favorable_id], favorable_id: params[:favorable_id], favorable_type: params[:favorable_type])
+      redirect_to login_path, notice: I18n.t('spree.login_to_add_favorite')
     end
   end
 end

--- a/app/views/spree/favorites/_product_link.html.erb
+++ b/app/views/spree/favorites/_product_link.html.erb
@@ -9,7 +9,8 @@
                           no_text: true,
                           remote: true,
                           id: "favorable_product_#{@product.id}",
-                          class: 'favorite_product_link fa fa-heart no-text with-tip' %>
+                          class: 'favorite_product_link fa fa-heart no-text with-tip',
+                          data: { favorable_id: @product.id, favorable_type: 'Spree::Product' } %>
   <% else %>
     <%= link_to_with_icon '',
                           t('spree.add_favorite'),
@@ -19,6 +20,7 @@
                           no_text: true,
                           remote: true,
                           id: "favorable_product_#{@product.id}",
-                          class: 'favorite_product_link fa fa-heart-o no-text with-tip' %>
+                          class: 'favorite_product_link fa fa-heart-o no-text with-tip',
+                          data: { favorable_id: @product.id, favorable_type: 'Spree::Product' } %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
     favorite_users: Favorite Users
     favorite_products: Favorite Products
     go_to_product: Visit product page
+    login_to_add_favorite: Please login to add to your favorites
+    login_to_view_favorites: Please login to view your favorites
     my_favorites: My Favorites
     remove_favorite: Remove Favorite
     successfully_added_favorite: Successfully added favorite.


### PR DESCRIPTION
If an unauthenticated user tries to mark a product as a favorite, she gets redirected to the login page.
Product is put into favorites upon logging in or registering.

Inspired by: https://github.com/vinsol/solidus_favorite_products/blob/76b9662706af450a2615d580cd63a95645fd3e95/app/controllers/spree/favorite_products_controller.rb#L35